### PR TITLE
Add pre-commit basic config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+fail_fast: true
+repos:
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: v2.1.0
+    hooks:
+    -   id: check-added-large-files
+        args:
+        - --maxkb=500
+    -   id: check-byte-order-marker
+    -   id: check-case-conflict
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: debug-statements
+    -   id: detect-private-key


### PR DESCRIPTION
This commit adds some pre-commit basic hooks to the project.

This will enable us to add, in the future, some local repo hooks like black and flake8.